### PR TITLE
Updating regex to allow for dashes in url

### DIFF
--- a/src/Mvp/Crud/CrudUrlHandler.php
+++ b/src/Mvp/Crud/CrudUrlHandler.php
@@ -112,7 +112,7 @@ class CrudUrlHandler extends MvpRestHandler
 
         $this->isCollection = true;
 
-        if (preg_match("|^" . $this->url . "([0-9]+)/([a-zA-Z0-9]+)|", $uri, $matches)) {
+        if (preg_match("|^" . $this->url . "([0-9]+)/([a-zA-Z0-9\-]+)|", $uri, $matches)) {
             if ($this->checkForPotentialAction($matches[2])) {
                 $this->urlAction = $matches[2];
                 $this->isCollection = false;


### PR DESCRIPTION
This functionality adds support for multiple words in URLs that are separated by dashes.
The function 'makeActionClassFriendly' allows for multiple words separated by a dash that is later on ucword-ed, how ever by this point the action name is incorrectly parsed by the Regex.

For example:
    /1/class-settings
would be parsed to Class and thus fail.

Using this functionality the above example would be parsed to ClassSettings and so would relate to the appropriate presenter.
